### PR TITLE
Allow specifying path to disk.xfs

### DIFF
--- a/disk.c
+++ b/disk.c
@@ -10,6 +10,13 @@ Interface to access disk file.
 #include <sys/types.h>
 
 BLOCK *disk;
+/* path to disk.xfs */
+static const char* pathToDisk = NULL;
+
+void setPathToDisk(const char* path) {
+    pathToDisk = path;
+}
+
 
 /* Reads an entire block from fileBlockNumber on the disk to virtBlockNumber on the memory copy of the disk */
 int readFromDisk(int virtBlockNumber, int fileBlockNumber)
@@ -39,7 +46,7 @@ int writeToDisk(int virtBlockNumber, int fileBlockNumber)
 /* Opens the disk file and returns the file descriptor */
 int openDiskFile(int access)
 {
-    int fd = open(DISK_NAME, access, 0666);
+    int fd = open(pathToDisk, access, 0666);
     if (fd < 0)
         exception_throwException(EXCEPTION_CANT_OPEN_DISK);
 
@@ -52,9 +59,9 @@ void createDiskFile(int format)
     int fd;
 
     if (format == DISK_FORMAT)
-        fd = open(DISK_NAME, O_CREAT | O_TRUNC | O_SYNC, 0666);
+        fd = open(pathToDisk, O_CREAT | O_TRUNC | O_SYNC, 0666);
     else
-        fd = open(DISK_NAME, O_CREAT, 0666);
+        fd = open(pathToDisk, O_CREAT, 0666);
 
     if (fd < 0)
         exception_throwException(EXCEPTION_CANT_CREATE_DISK);

--- a/disk.h
+++ b/disk.h
@@ -5,7 +5,6 @@
 #include "fileSystem.h"
 #include "exception.h"
 
-#define DISK_NAME "disk.xfs"
 
 #define DISK_NO_FORMAT 0
 #define DISK_FORMAT 1
@@ -15,6 +14,7 @@ typedef struct
     char word[BLOCK_SIZE][WORD_SIZE];
 } BLOCK;
 
+void setPathToDisk(const char* path);
 int readFromDisk(int virtBlockNumber, int fileBlockNumber);
 int writeToDisk(int virtBlockNumber, int fileBlockNumber);
 int openDiskFile(int access);

--- a/interface.c
+++ b/interface.c
@@ -560,7 +560,31 @@ int main(int argc, char **argv)
 
     disk_init();
 
-    fd = open(DISK_NAME, O_RDONLY, 0666);
+    const char* disk_file = DEFAULT_DISK_NAME;
+
+    if(argc>1 && strcmp(argv[1], "--disk-file")==0)
+    {
+        argc --;
+        argv ++;
+        if(argc>1)
+        {
+            disk_file = argv[1];
+            argc --;
+            argv ++;
+        }
+        else
+        {
+            printf("--disk-file option requires a file name.\n");
+            printf("\n");
+            printf("Syntax: --disk-file /path/to/disk.xfs\n");
+            printf("Specifies the path to disk.xfs to use.\n");
+            exit(-1);
+        }
+    }
+
+    setPathToDisk(disk_file);
+
+    fd = open(disk_file, O_RDONLY, 0666);
     if (fd > 0)
     {
         close(fd);

--- a/interface.h
+++ b/interface.h
@@ -8,6 +8,8 @@
 #define DO_NOT_FORMAT 0
 #define FORMAT 1
 
+#define DEFAULT_DISK_NAME "disk.xfs"
+
 void cli(int argc, char **argv);
 void runCommand(char command[]);
 char *xfs_cli_stripwhite(char *str);


### PR DESCRIPTION
Provide `--disk-file /path/to/disk.xfs` command line option.
Default value is `disk.xfs` for backwards compatibility.