### PR TITLE
Ignore empty lines in xsm files

### DIFF
--- a/labels.c
+++ b/labels.c
@@ -138,7 +138,7 @@ int labels_phase_one(FILE *fp)
             label = labels_get_name(instruction);
             labels_insert(label, address);
         }
-        else
+        else if (strlen(instruction) > 0)
             address += XSM_INSTRUCTION_SIZE;
     }
 


### PR DESCRIPTION
XFS interface doesn't ignore empty lines while calculating label addresses but removes them while loading onto the disk.